### PR TITLE
Update POM for add LICENSE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,14 @@
         <system>GitHub Issues</system>
     </issueManagement>
 
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://www.opensource.org/licenses/mit-license.php</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
Only add the license into POM for the repository.
Suggest: add developers into repository.